### PR TITLE
Implement async support

### DIFF
--- a/autoload/import_cost/async.vim
+++ b/autoload/import_cost/async.vim
@@ -1,0 +1,73 @@
+" This script contains some higher-level support for async operation in both
+" Neovim and Vim 8. Please nore that these implementations are *VERY* simple and
+" targerting the use case of this specific plguin.
+
+" Most of following functions assumes that the check for async support
+" (`import_cost#async#IsAsyncSupported()`) was done before.
+
+" Check wether the current version of the editor supports async jobs
+function! import_cost#async#is_supported()
+  return has('nvim') || v:version >= 800
+endfunction
+
+" Starts a new async job and returns the job id
+" The callback function should have the following signature:
+"
+"     `function! JobCallback(data, event)`
+"
+" Where `data` is a string containing the data received, and `event` is the
+" event type (can be one of `stdin`, `stderr`, `exit`). The `data` for the
+" `exit` event is the exit code.
+"
+function! import_cost#async#job_start(command, callback)
+  if has('nvim')
+
+    " 'Converting' neovim's callback function to our 'basic' callback
+    " signature
+    let l:TransformedCallback = {job_id, data, event ->
+          \ a:callback(type(data) == 3 ? join(data, "\n") : data, event)}
+
+    let l:job_id = jobstart(a:command, {
+          \ 'shell': 'import_cost_shell',
+          \ 'on_stdout': l:TransformedCallback,
+          \ 'on_stderr': l:TransformedCallback,
+          \ 'on_exit': l:TransformedCallback,
+          \ })
+  else
+    let l:job_id = job_start(a:command, {
+          \ 'callback': {channel, data -> a:callback(data, 'stdout')},
+          \ 'err_cb': {channel, data -> a:callback(data, 'stderr')},
+          \ 'exit_cb': {job_id, exit_code -> a:callback(exit_code, 'exit')},
+          \ 'mode': 'raw',
+          \ })
+  endif
+
+  return l:job_id
+endfunction
+
+" Stops a job
+function! import_cost#async#job_stop(job_id)
+  if has('nvim')
+    call jobstop(a:job_id)
+  else
+    call job_stop(a:job_id)
+  endif
+endfunction
+
+" Send an input to a job via stdin
+function! import_cost#async#job_send(job_id, data)
+  if has('nvim')
+    call chansend(a:job_id, a:data)
+  else
+    call ch_sendraw(job_getchannel(a:job_id), a:data)
+  endif
+endfunction
+
+" Close the stdin channel for a job
+function! import_cost#async#job_close(job_id)
+  if has('nvim')
+    call chanclose(a:job_id, 'stdin')
+  else
+    call ch_close_in(job_getchannel(a:job_id))
+  endif
+endfunction

--- a/doc/import_cost.txt
+++ b/doc/import_cost.txt
@@ -99,7 +99,7 @@ there is only one option: >
     let g:import_cost_always_open_split = 1
 <
 Value: 0 or 1
-Default: 0 (only open split when there are more than 1 results)
+Default: 1 (always open a split)
 
 ------------------------------------------------------------------------------
 g:import_cost_split_size                            *g:import_cost_split_size*
@@ -121,6 +121,21 @@ This option controls where to open output window: >
 <
 Value: "left", "right"
 Default: "left"
+
+------------------------------------------------------------------------------
+g:import_cost_disable_async                      *g:import_cost_disable_async*
+
+When this option is on, the imports size calculation will be run
+synchronously. This is not recommended, as it will cause the UI to block until
+the execution is complete.
+
+If you are running a version without asynchronous capabilities, this option is
+enabled by default. >
+
+    let g:import_cost_disable_async = 1
+<
+Value: 0 or 1
+Default: 0 (use asynchronous execution)
 
 ==============================================================================
 LICENSE                                                  *import-cost-license*

--- a/plugin/import_cost.vim
+++ b/plugin/import_cost.vim
@@ -31,9 +31,10 @@ endfunction
 
 let s:default_settings = {
   \ 'show_gzipped': 1,
-  \ 'always_open_split': 0,
+  \ 'always_open_split': 1,
   \ 'split_size': 50,
   \ 'split_pos': 'left',
+  \ 'disable_async': 0,
   \ }
 
 call s:InitSettings(s:default_settings)


### PR DESCRIPTION
Currently, the calculation script runs synchronously, meaning it will block the editor UI until it completes.

This PR adds an async support. The script will run in the background and the results will be populated when it'll finish. This features support **both** NeoVim and Vim 8.

When using an unsupported version, or when setting `g:import_cost_disable_async` to `1`, the synchronous execution will be used.

In addition, `g:import_cost_always_open_split` is set to `1` by default, since the command can be used in an autocommand (e.g. `autocmd InsertLeave * ImportCost`), and the expected behaviour is to always update the results buffer even if there is a single import.
