### PR TITLE
Use virtualtext on nvim to display results

### DIFF
--- a/autoload/import_cost.vim
+++ b/autoload/import_cost.vim
@@ -42,7 +42,7 @@ function! s:EchoError(msg)
 endfunction
 
 " Check if virtualtext is supported
-function! s:IsVirtualTextSupported()
+function! import_cost#IsVirtualTextSupported()
     return has('nvim-0.3.2')
 endfunction
 
@@ -250,7 +250,7 @@ function! s:OnScriptFinish()
 
   " Check for errors
   if len(s:import_cost_stderr)
-    if !s:IsVirtualTextSupported()
+    if !import_cost#IsVirtualTextSupported()
       call s:EchoError(s:import_cost_stderr)
     else
       let l:buffer = bufnr('')
@@ -280,7 +280,7 @@ function! s:OnScriptFinish()
   " Create a new scratch buffer and fill it
   " Keep the focus on the currently opened buffer
   if l:imports_length > 0
-    if s:IsVirtualTextSupported()
+    if import_cost#IsVirtualTextSupported()
       call s:ShowVirtualTextMessage(l:imports, s:range_start_line, s:buffer_lines)
     else
       let l:current_buffer_name = bufname('%')

--- a/autoload/import_cost.vim
+++ b/autoload/import_cost.vim
@@ -41,6 +41,11 @@ function! s:EchoError(msg)
   echohl None
 endfunction
 
+" Check if virtualtext is supported
+function! s:IsVirtualTextSupported()
+    return has('nvim-0.3.2')
+endfunction
+
 " Pretty format a size in bytes
 function! s:PrettyFormatSize(size)
   let l:pretty_size = a:size / 1000.0
@@ -245,7 +250,7 @@ function! s:OnScriptFinish()
 
   " Check for errors
   if len(s:import_cost_stderr)
-    if !has('nvim-0.3.2')
+    if !s:IsVirtualTextSupported()
       call s:EchoError(s:import_cost_stderr)
     else
       let l:buffer = bufnr('')
@@ -275,7 +280,7 @@ function! s:OnScriptFinish()
   " Create a new scratch buffer and fill it
   " Keep the focus on the currently opened buffer
   if l:imports_length > 0
-    if has('nvim-0.3.2')
+    if s:IsVirtualTextSupported()
       call s:ShowVirtualTextMessage(l:imports, s:range_start_line, s:buffer_lines)
     else
       let l:current_buffer_name = bufname('%')

--- a/autoload/import_cost.vim
+++ b/autoload/import_cost.vim
@@ -250,7 +250,7 @@ function! s:OnScriptFinish()
 
   " Check for errors
   if len(s:import_cost_stderr)
-    if !import_cost#IsVirtualTextSupported()
+    if !(import_cost#IsVirtualTextSupported() && g:import_cost_virtualtext)
       call s:EchoError(s:import_cost_stderr)
     else
       let l:buffer = bufnr('')
@@ -280,7 +280,7 @@ function! s:OnScriptFinish()
   " Create a new scratch buffer and fill it
   " Keep the focus on the currently opened buffer
   if l:imports_length > 0
-    if import_cost#IsVirtualTextSupported()
+    if import_cost#IsVirtualTextSupported() && g:import_cost_virtualtext
       call s:ShowVirtualTextMessage(l:imports, s:range_start_line, s:buffer_lines)
     else
       let l:current_buffer_name = bufname('%')
@@ -299,7 +299,7 @@ function! s:OnScriptFinish()
 
   endif
 
-  if !g:import_cost_silent
+  if !(import_cost#IsVirtualTextSupported() && g:import_cost_virtualtext)
     echom l:result_message
   endif
 endfunction

--- a/autoload/import_cost.vim
+++ b/autoload/import_cost.vim
@@ -245,7 +245,12 @@ function! s:OnScriptFinish()
 
   " Check for errors
   if len(s:import_cost_stderr)
-    call s:EchoError(s:import_cost_stderr)
+    if !has('nvim-0.3.2')
+      call s:EchoError(s:import_cost_stderr)
+    else
+      let l:buffer = bufnr('')
+      call nvim_buf_clear_highlight(l:buffer, 1000, 0, -1)
+    endif
     return
   endif
 

--- a/autoload/import_cost.vim
+++ b/autoload/import_cost.vim
@@ -299,7 +299,9 @@ function! s:OnScriptFinish()
 
   endif
 
-  echom l:result_message
+  if !g:import_cost_silent
+    echom l:result_message
+  endif
 endfunction
 
 " }}}

--- a/doc/import_cost.txt
+++ b/doc/import_cost.txt
@@ -196,6 +196,17 @@ This options sets the prefix used to when displaying the import cost info.
 Value: string
 Default: ">"
 
+------------------------------------------------------------------------------
+g:import_cost_silent                                    *g:import_cost_silent*
+
+This option will silence the output of import_cost if it is a successs.
+ >
+
+    let g:import_cost_silent = 1
+<
+Value: 0 or 1
+Default: 0
+
 ==============================================================================
 LICENSE                                                  *import-cost-license*
 

--- a/doc/import_cost.txt
+++ b/doc/import_cost.txt
@@ -191,7 +191,7 @@ g:import_cost_virtualtext_prefix          *g:import_cost_virtualtext_prefix*
 This options sets the prefix used to when displaying the import cost info.
  >
 
-    let g:import_cost_virtualtext_hl_group = " :: "
+    let g:import_cost_virtualtext_prefix = " :: "
 <
 Value: string
 Default: ">"

--- a/doc/import_cost.txt
+++ b/doc/import_cost.txt
@@ -158,6 +158,44 @@ enabled by default. >
 Value: 0 or 1
 Default: 0 (use asynchronous execution)
 
+------------------------------------------------------------------------------
+g:import_cost_disable_virtualtext          *g:import_cost_disable_virtualtext*
+
+When this option is on, it will disable the use of virtualtext feature that
+will show the result to the right of the import and instead display the
+result in a split.
+
+If you are running a version without virtualtext, this option is assumed to be
+set to true.
+ >
+
+    let g:import_cost_disable_virtualtext = 1
+<
+Value: 0 or 1
+Default: 0 (use virtualtext insted of split)
+
+------------------------------------------------------------------------------
+g:import_cost_virtualtext_hl_group          *g:import_cost_virtualtext_hl_group*
+
+This options control what highlight group will be used to show the info.
+ >
+
+    let g:import_cost_virtualtext_hl_group = "LineNr"
+<
+Value: string
+Default: "LineNr"
+
+------------------------------------------------------------------------------
+g:import_cost_virtualtext_prefix          *g:import_cost_virtualtext_prefix*
+
+This options sets the prefix used to when displaying the import cost info.
+ >
+
+    let g:import_cost_virtualtext_hl_group = " :: "
+<
+Value: string
+Default: ">"
+
 ==============================================================================
 LICENSE                                                  *import-cost-license*
 

--- a/doc/import_cost.txt
+++ b/doc/import_cost.txt
@@ -159,7 +159,7 @@ Value: 0 or 1
 Default: 0 (use asynchronous execution)
 
 ------------------------------------------------------------------------------
-g:import_cost_disable_virtualtext          *g:import_cost_disable_virtualtext*
+g:import_cost_virtualtext                          *g:import_cost_virtualtext*
 
 When this option is on, it will disable the use of virtualtext feature that
 will show the result to the right of the import and instead display the
@@ -169,10 +169,10 @@ If you are running a version without virtualtext, this option is assumed to be
 set to true.
  >
 
-    let g:import_cost_disable_virtualtext = 1
+    let g:import_cost_virtualtext = 0
 <
 Value: 0 or 1
-Default: 0 (use virtualtext insted of split)
+Default: 1 (use virtualtext insted of split if available)
 
 ------------------------------------------------------------------------------
 g:import_cost_virtualtext_hl_group          *g:import_cost_virtualtext_hl_group*

--- a/doc/import_cost.txt
+++ b/doc/import_cost.txt
@@ -166,7 +166,7 @@ will show the result to the right of the import and instead display the
 result in a split.
 
 If you are running a version without virtualtext, this option is assumed to be
-set to true.
+set to false.
  >
 
     let g:import_cost_virtualtext = 0

--- a/doc/import_cost.txt
+++ b/doc/import_cost.txt
@@ -196,17 +196,6 @@ This options sets the prefix used to when displaying the import cost info.
 Value: string
 Default: ">"
 
-------------------------------------------------------------------------------
-g:import_cost_silent                                    *g:import_cost_silent*
-
-This option will silence the output of import_cost if it is a successs.
- >
-
-    let g:import_cost_silent = 1
-<
-Value: 0 or 1
-Default: 0
-
 ==============================================================================
 LICENSE                                                  *import-cost-license*
 

--- a/plugin/import_cost.vim
+++ b/plugin/import_cost.vim
@@ -35,8 +35,7 @@ let s:default_settings = {
   \ 'split_size': 50,
   \ 'split_pos': 'left',
   \ 'disable_async': 0,
-  \ 'disable_auto': 0,
-  \ 'silent': 0,
+  \ 'virtualtext': 1,
   \ }
 
 call s:InitSettings(s:default_settings)
@@ -48,7 +47,7 @@ function! s:InitCommands()
   command! -buffer -range=0 ImportCost call import_cost#ImportCost(<count>, <line1>, <line2>)
   command! -buffer          ImportCostSingle call import_cost#ImportCost(1, <line1>, <line1>)
 
-  if import_cost#IsVirtualTextSupported() && !g:import_cost_disable_auto && !g:import_cost_disable_async
+  if import_cost#IsVirtualTextSupported() && g:import_cost_virtualtext && !g:import_cost_disable_async
     augroup import_cost_auto_run
       autocmd!
       autocmd InsertLeave * call import_cost#ImportCost(0, 0 ,0)

--- a/plugin/import_cost.vim
+++ b/plugin/import_cost.vim
@@ -35,6 +35,7 @@ let s:default_settings = {
   \ 'split_size': 50,
   \ 'split_pos': 'left',
   \ 'disable_async': 0,
+  \ 'disable_auto': 0,
   \ }
 
 call s:InitSettings(s:default_settings)
@@ -46,12 +47,14 @@ function! s:InitCommands()
   command! -buffer -range=0 ImportCost call import_cost#ImportCost(<count>, <line1>, <line2>)
   command! -buffer          ImportCostSingle call import_cost#ImportCost(1, <line1>, <line1>)
 
-  augroup import_cost_auto_run
-    autocmd!
-    autocmd InsertLeave * call import_cost#ImportCost(0, 0 ,0)
-    autocmd BufEnter * call import_cost#ImportCost(0, 0 ,0)
-    autocmd CursorHold * call import_cost#ImportCost(0, 0 ,0)
-  augroup END
+  if import_cost#IsVirtualTextSupported() && !g:import_cost_disable_auto && !g:import_cost_disable_async
+    augroup import_cost_auto_run
+      autocmd!
+      autocmd InsertLeave * call import_cost#ImportCost(0, 0 ,0)
+      autocmd BufEnter * call import_cost#ImportCost(0, 0 ,0)
+      autocmd CursorHold * call import_cost#ImportCost(0, 0 ,0)
+    augroup END
+  endif
 endfunction
 
 " }}}

--- a/plugin/import_cost.vim
+++ b/plugin/import_cost.vim
@@ -36,6 +36,7 @@ let s:default_settings = {
   \ 'split_pos': 'left',
   \ 'disable_async': 0,
   \ 'disable_auto': 0,
+  \ 'silent': 0,
   \ }
 
 call s:InitSettings(s:default_settings)

--- a/plugin/import_cost.vim
+++ b/plugin/import_cost.vim
@@ -45,6 +45,13 @@ call s:InitSettings(s:default_settings)
 function! s:InitCommands()
   command! -buffer -range=0 ImportCost call import_cost#ImportCost(<count>, <line1>, <line2>)
   command! -buffer          ImportCostSingle call import_cost#ImportCost(1, <line1>, <line1>)
+
+  augroup import_cost_auto_run
+    autocmd!
+    autocmd InsertLeave * call import_cost#ImportCost(0, 0 ,0)
+    autocmd BufEnter * call import_cost#ImportCost(0, 0 ,0)
+    autocmd CursorHold * call import_cost#ImportCost(0, 0 ,0)
+  augroup END
 endfunction
 
 " }}}


### PR DESCRIPTION
![](https://i.imgur.com/2rbeRZm.png)


With this PR (https://github.com/neovim/neovim/pull/8180) neovim has support to display text that is not part of the file in a buffer. Using this instead of opening a new split will be a better way to display the size.

> Docs need to be added.


### Two new variables
`g:import_cost_virtualtext_hl_group` : set highlight group (default LineNr)
`g:import_cost_virtualtext_prefix`: prefix for virtualtext ( default > )