### PR TITLE
chore: update import-cost dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "get-stdin": "^6.0.0",
-    "import-cost": "^1.5.0"
+    "import-cost": "^1.8.0"
   },
   "devDependencies": {
     "eslint": "^4.19.1",


### PR DESCRIPTION
Fix monorepo issue reported in #18 with upstream update