### PR TITLE
Add option for messages being silent.

### DIFF
--- a/autoload/import_cost.vim
+++ b/autoload/import_cost.vim
@@ -11,6 +11,10 @@ let s:range_start_line = 0
 
 " Echo an error message
 function! s:EchoError(msg)
+  if g:import_cost_silent
+    return
+  endif
+
   echohl Error
   echom 'vim-import-cost: ' . a:msg
   echohl None
@@ -36,9 +40,7 @@ function! s:OnEvent(type, payload)
       call import_cost#virtual_text#Clear()
     endif
 
-    if !g:import_cost_silent
-      call s:EchoError(a:payload)
-    endif
+    call s:EchoError(a:payload)
     return
   endif
 

--- a/autoload/import_cost.vim
+++ b/autoload/import_cost.vim
@@ -36,7 +36,9 @@ function! s:OnEvent(type, payload)
       call import_cost#virtual_text#Clear()
     endif
 
-    call s:EchoError(a:payload)
+    if !g:import_cost_silent
+      call s:EchoError(a:payload)
+    endif
     return
   endif
 

--- a/doc/import_cost.txt
+++ b/doc/import_cost.txt
@@ -205,6 +205,17 @@ the virtual text feature.
 Value: string
 Default: " > "
 
+------------------------------------------------------------------------------
+g:import_cost_slient                                    *g:import_cost_silent*
+
+When this option is on, the plugin does not echo error messages.
+ >
+    let g:import_cost_silent = 1
+<
+Value: 0 or 1
+Default: 0
+
+
 ==============================================================================
 HIGHLIGHTS                                            *import-cost-highlights*
 

--- a/plugin/import_cost.vim
+++ b/plugin/import_cost.vim
@@ -37,6 +37,7 @@ let s:default_settings = {
   \ 'disable_async': 0,
   \ 'virtualtext': 1,
   \ 'virtualtext_prefix': ' > ',
+  \ 'silent': 0,
   \ }
 
 call s:InitSettings(s:default_settings)


### PR DESCRIPTION
Thanks for this great plugin!

This is a little option to disable echoing error messages.

I am checking errors with other plugins, and this error message usually shows syntax error which I do not always need.

